### PR TITLE
Add centroid_test_data/sweep.json

### DIFF
--- a/dials_data/definitions/centroid_test_data.yml
+++ b/dials_data/definitions/centroid_test_data.yml
@@ -32,4 +32,5 @@ data:
   - url: https://github.com/dials/data-files/raw/8fe7910a15c361a1f69012662b3f001f4db3cbe0/centroid_test_data/mask.pickle
   - url: https://github.com/dials/data-files/raw/8fe7910a15c361a1f69012662b3f001f4db3cbe0/centroid_test_data/SPOT.XDS
   - url: https://github.com/dials/data-files/raw/8fe7910a15c361a1f69012662b3f001f4db3cbe0/centroid_test_data/strong.pickle
+  - url: https://github.com/dials/data-files/raw/42747fbfaed07b7a4cfe6a2bcb00de3b112fbe29/centroid_test_data/sweep.json
   - url: https://github.com/dials/data-files/raw/8fe7910a15c361a1f69012662b3f001f4db3cbe0/centroid_test_data/XDS.INP


### PR DESCRIPTION
for remaining dials test.

dxtbx adds a few more `.pickle` files from the directory, but I haven't added them yet as they compress exceedingly well (>90 MB -> <15 kB), so I'll want to work on #12 first.