### PR TITLE
Change pytest --regression interaction to fix crash

### DIFF
--- a/dials_data/__init__.py
+++ b/dials_data/__init__.py
@@ -19,15 +19,17 @@ __version_tuple__ = tuple(int(x) for x in __version__.split("."))
 
 
 def pytest_addoption(parser):
-    """Adds '--regression' option to pytest exactly once."""
-    if not hasattr(pytest_addoption, "done"):
+    """Adds '--regression' option to pytest if required."""
+    try:
         parser.addoption(
             "--regression",
             action="store_true",
             default=False,
             help="run regression tests. Download data for those tests if required",
         )
-    setattr(pytest_addoption, "done", True)
+    except ValueError:
+        # The Pytest parser already has this option added elsewhere
+        pass
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
If e.g. `dials` or `dxtbx` was added into pytest first, this would cause a crash.

The old way had at least two problems:
- `addoption("--regression",...`' could have been called by another package, which the "have I been called" check wouldn't fix
- The pytest_addoption function could have been previously called, but for
  a different pytest parser. This would kill e.g. pytest reentrancy

This leans on EAFP to fix both these issues, though it might be better to register as an actual plugin to add the shared option?