### PR TITLE
Add definition for datafiles of four scaled sweeps of L-cysteine

### DIFF
--- a/dials_data/definitions/l_cysteine_4_sweeps_scaled.yml
+++ b/dials_data/definitions/l_cysteine_4_sweeps_scaled.yml
@@ -1,0 +1,20 @@
+name: A dataset of 4 scaled sweeps of L-cysteine
+author: James Beilsten-Edmands (2019)
+license: CC-BY 4.0
+description: >
+  Example DIALS scaled data, of four sweeps of l-cysteine scaled together,
+  which were then split into datafiles containing two sweeps and two
+  datafiles containing one sweep each. Scaled using dials master branch
+  version 3d17bb2 on 18/07/19. Generated from dials integrated data,
+  known as xia2-28 in the dials_regression repository. Originally derived
+  from data collected on I19-1 at Diamond Light Source, U.K.
+
+  Useful input for testing dials programs post-scaling.
+
+data:
+ - url: https://github.com/dials/data-files/raw/4fd2c77a8cc94cc6b5031ea37adc4e8a6a8821b5/l_cysteine_4_sweeps_scaled/scaled_20_25.expt
+ - url: https://github.com/dials/data-files/raw/4fd2c77a8cc94cc6b5031ea37adc4e8a6a8821b5/l_cysteine_4_sweeps_scaled/scaled_30.expt
+ - url: https://github.com/dials/data-files/raw/4fd2c77a8cc94cc6b5031ea37adc4e8a6a8821b5/l_cysteine_4_sweeps_scaled/scaled_35.expt
+ - url: https://github.com/dials/data-files/raw/4fd2c77a8cc94cc6b5031ea37adc4e8a6a8821b5/l_cysteine_4_sweeps_scaled/scaled_20_25.refl
+ - url: https://github.com/dials/data-files/raw/4fd2c77a8cc94cc6b5031ea37adc4e8a6a8821b5/l_cysteine_4_sweeps_scaled/scaled_30.refl
+ - url: https://github.com/dials/data-files/raw/4fd2c77a8cc94cc6b5031ea37adc4e8a6a8821b5/l_cysteine_4_sweeps_scaled/scaled_35.refl


### PR DESCRIPTION
Add definition for recently scaled l-cysteine data for testing post-scaling dials programs e.g dials.export, dials.merge etc.