### PR TITLE
Add further files for dxtbx tests

### DIFF
--- a/dials_data/definitions/centroid_test_data.yml
+++ b/dials_data/definitions/centroid_test_data.yml
@@ -4,7 +4,7 @@ license: CC-BY 4.0
 description: >
   Data originally collected on I02 on 2013-02-08 as part of visit nt5964-1
 
-  Useful as centroid test data for DIALS.
+  Useful as centroid test data for DIALS and dxtbx.
 
   The complex cation lambda-[Ru(1,4,5,8-tetraazaphenanthrene)2(dipyridophenazine)]2+
   crystallizes in a 1:1 ratio with the oligonucleotide d(TCGGCGCCGA) in the

--- a/dials_data/definitions/centroid_test_data.yml
+++ b/dials_data/definitions/centroid_test_data.yml
@@ -22,7 +22,11 @@ data:
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/centroid_0009.cbf
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/crystal.json
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/datablock.json
+  - url: https://github.com/dials/data-files/raw/12c29cae96057da91a2da5c5ce042846cf9a79fa/centroid_test_data/datablock_with_bad_lookup.json
+  - url: https://github.com/dials/data-files/raw/12c29cae96057da91a2da5c5ce042846cf9a79fa/centroid_test_data/datablock_with_lookup.json
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/experiments.json
+  - url: https://github.com/dials/data-files/raw/12c29cae96057da91a2da5c5ce042846cf9a79fa/centroid_test_data/experiments_with_bad_lookup.json
+  - url: https://github.com/dials/data-files/raw/12c29cae96057da91a2da5c5ce042846cf9a79fa/centroid_test_data/experiments_with_lookup.json
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/fake_long_experiments.json
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/imported_experiments.json
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/integrated.pickle


### PR DESCRIPTION
These files are used in dxtbx for centroid_test_data related tests.