### PR TITLE
Rename dials-for-ed dataset

### DIFF
--- a/dials_data/definitions/lysozyme_electron_diffraction.yml
+++ b/dials_data/definitions/lysozyme_electron_diffraction.yml
@@ -1,10 +1,12 @@
 name: Lysozyme electron diffraction MTZ file
 author: David Waterman (2019)
 license: CC-BY 4.0
+url: https://doi.org/10.1107/S2059798318007726
 description: >
   A refined MTZ derived from DIALS processing of electron diffraction
   data collected from a lysozyme nanocrystal, discussed in the paper
   https://doi.org/10.1107/S2059798318007726.
 
 data:
- - url: https://github.com/dials/data-files/raw/80840b5cd2d6d75dd05859cabc27e844a7344049/DIALS_for_ED_test_data/refmac_final.mtz
+ - url: https://github.com/dials/data-files/raw/1916a8649e9f505199949f90822165d368c93872/lysozyme_ED_processed/README.md
+ - url: https://github.com/dials/data-files/raw/1916a8649e9f505199949f90822165d368c93872/lysozyme_ED_processed/refmac_final.mtz

--- a/dials_data/definitions/lysozyme_electron_diffraction.yml
+++ b/dials_data/definitions/lysozyme_electron_diffraction.yml
@@ -1,0 +1,10 @@
+name: Lysozyme electron diffraction MTZ file
+author: David Waterman (2019)
+license: CC-BY 4.0
+description: >
+  A refined MTZ derived from DIALS processing of electron diffraction
+  data collected from a lysozyme nanocrystal, discussed in the paper
+  https://doi.org/10.1107/S2059798318007726.
+
+data:
+ - url: https://github.com/dials/data-files/raw/80840b5cd2d6d75dd05859cabc27e844a7344049/DIALS_for_ED_test_data/refmac_final.mtz

--- a/dials_data/definitions/simulated_lysozyme.yml
+++ b/dials_data/definitions/simulated_lysozyme.yml
@@ -1,9 +1,0 @@
-name: Simulated Lysozyme .mtz
-author: David Waterman (2019)
-license: CC-BY 4.0
-description: >
-  A refined MTZ derived from DIALS processing of a dataset of a simulated
-  electron diffraction experiment with a Lysozyme sample.
-
-data:
- - url: https://github.com/dials/data-files/raw/80840b5cd2d6d75dd05859cabc27e844a7344049/DIALS_for_ED_test_data/refmac_final.mtz

--- a/dials_data/definitions/simulated_lysozyme.yml
+++ b/dials_data/definitions/simulated_lysozyme.yml
@@ -1,8 +1,9 @@
-name: DIALS for ED
+name: Simulated Lysozyme .mtz
 author: David Waterman (2019)
 license: CC-BY 4.0
 description: >
-  A refined MTZ derived from DIALS processing of electron diffraction data
+  A refined MTZ derived from DIALS processing of a dataset of a simulated
+  electron diffraction experiment with a Lysozyme sample.
 
 data:
  - url: https://github.com/dials/data-files/raw/80840b5cd2d6d75dd05859cabc27e844a7344049/DIALS_for_ED_test_data/refmac_final.mtz


### PR DESCRIPTION
Following from my comments in #83 this is what I would propose:

1. rename the dataset to something descriptive of the dataset (`simulated_lysozyme`), rather than something describing the intended use you have for it (`dials-for-ed`).
  Other people can get a list of datasets included in dials.data by running `dials.data list`. We should not specify what the data can be used for, or even how we intend to use it. Just be clear about what the data are and where they come from, and then other people (including future-us) will find uses for the data.

2. In that vein - if we had any more information on where the data come from (Simulated how? Is the simulated dataset available? Are the instructions that were used to simulate the dataset available? How was it processed? Commands? Versions?) that would be useful to go either into the description on into a `README` file next to the `.mtz`. I would also propose renaming the directory in the data-files repository accordingly (but this is an independent issue)