### PR TITLE
Add Dectris Eiger single-image test data

### DIFF
--- a/dials_data/definitions/image_examples.yml
+++ b/dials_data/definitions/image_examples.yml
@@ -13,5 +13,5 @@ data:
   - url: https://github.com/dials/data-files/raw/1916a8649e9f505199949f90822165d368c93872/image_examples/simtbx_FormatSMVJHSim_001.img
   - url: https://github.com/dials/data-files/raw/1916a8649e9f505199949f90822165d368c93872/image_examples/TIMEPIX_SU_512-stdgoni_0001.img
   - url: https://github.com/dials/data-files/raw/1916a8649e9f505199949f90822165d368c93872/image_examples/TIMEPIX_SU_516-stdgoni_0001.img
-  - url: https://github.com/dials/data-files/raw/4181be4aca78e62f26c5fa90e5ac44599a420c54/image_examples/dectris_eiger_data_000001.h5
-  - url: https://github.com/dials/data-files/raw/4181be4aca78e62f26c5fa90e5ac44599a420c54/image_examples/dectris_eiger_master.h5
+  - url: https://github.com/dials/data-files/raw/7260492a487e88dde58f8be044b21cef1c7578ef/image_examples/dectris_eiger_data_000001.h5
+  - url: https://github.com/dials/data-files/raw/7260492a487e88dde58f8be044b21cef1c7578ef/image_examples/dectris_eiger_master.h5

--- a/dials_data/definitions/image_examples.yml
+++ b/dials_data/definitions/image_examples.yml
@@ -13,3 +13,5 @@ data:
   - url: https://github.com/dials/data-files/raw/1916a8649e9f505199949f90822165d368c93872/image_examples/simtbx_FormatSMVJHSim_001.img
   - url: https://github.com/dials/data-files/raw/1916a8649e9f505199949f90822165d368c93872/image_examples/TIMEPIX_SU_512-stdgoni_0001.img
   - url: https://github.com/dials/data-files/raw/1916a8649e9f505199949f90822165d368c93872/image_examples/TIMEPIX_SU_516-stdgoni_0001.img
+  - url: https://github.com/dials/data-files/raw/4181be4aca78e62f26c5fa90e5ac44599a420c54/image_examples/dectris_eiger_data_000001.h5
+  - url: https://github.com/dials/data-files/raw/4181be4aca78e62f26c5fa90e5ac44599a420c54/image_examples/dectris_eiger_master.h5


### PR DESCRIPTION
Add single-image Eiger test data in Dectris' standard nearly-NeXus format.

Details of these semi-synthetic data are kept in the repository where the files are stored:
https://github.com/dials/data-files/tree/master/image_examples