### PR TITLE
Stick with older version of mock

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,6 +8,10 @@ update_configs:
       - match:
           dependency_name: "bump2version"
           version_requirement: ">=1"
+      # mock 4 requires Python 3.6+
+      - match:
+          dependency_name: "mock"
+          version_requirement: ">=4"
       # pytest 5 requires Python 3
       - match:
           dependency_name: "pytest"


### PR DESCRIPTION
until September when Python 3.5 is EOL.
Closes #164