### PR TITLE
Add links to l-cysteine image data

### DIFF
--- a/dials_data/definitions/l_cysteine_dials_output.yml
+++ b/dials_data/definitions/l_cysteine_dials_output.yml
@@ -7,10 +7,6 @@ description: >
   These were derived from the DIALS small molecule tutorial L-cysteine dataset
   (https://zenodo.org/record/51405 files l-cyst_0[1-4].tar.gz).
 
-  On a linux terminal, the relevant CBF-format image files can be obtained with
-  $ curl -O https://zenodo.org/record/51405/files/l-cyst_0[1-4].tar.gz
-  $ ls *tar.gz | xargs -i tar xzf {}
-
   The imported.expt file was then generated using
   $ dials.import allow_multiple_sweeps=True l-cyst_0*cbf
 
@@ -35,3 +31,43 @@ data:
   - url: https://github.com/dials/data-files/raw/6c80c466777cb9cf5a14f963485364461e5a6ea5/l_cysteine_integrated/30_integrated_experiments.json
   - url: https://github.com/dials/data-files/raw/6c80c466777cb9cf5a14f963485364461e5a6ea5/l_cysteine_integrated/35_integrated.pickle
   - url: https://github.com/dials/data-files/raw/6c80c466777cb9cf5a14f963485364461e5a6ea5/l_cysteine_integrated/35_integrated_experiments.json
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00001.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00002.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00003.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00004.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00005.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00006.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00007.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00008.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00009.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00010.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00001.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00002.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00003.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00004.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00005.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00006.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00007.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00008.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00009.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00010.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00001.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00002.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00003.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00004.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00005.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00006.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00007.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00008.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00009.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00010.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00001.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00002.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00003.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00004.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00005.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00006.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00007.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00008.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00009.cbf
+  - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00010.cbf


### PR DESCRIPTION
At the moment, these are links from dials/data-files, but in the future
they can be links from Zenodo, see #172.