### PR TITLE
Add five more CBFs per sweep of a four-sweep set

### DIFF
--- a/dials_data/definitions/l_cysteine_dials_output.yml
+++ b/dials_data/definitions/l_cysteine_dials_output.yml
@@ -6,6 +6,7 @@ description: >
 
   These were derived from the DIALS small molecule tutorial L-cysteine dataset
   (https://zenodo.org/record/51405 files l-cyst_0[1-4].tar.gz).
+  The first 15 images from each sweep (corresponding to 1.5° wedges) are also included here.
 
   The imported.expt file was then generated using
   $ dials.import allow_multiple_sweeps=True l-cyst_0*cbf
@@ -48,6 +49,11 @@ data:
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00008.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00009.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00010.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_01_00011.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_01_00012.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_01_00013.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_01_00014.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_01_00015.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00001.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00002.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00003.cbf
@@ -58,6 +64,11 @@ data:
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00008.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00009.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_02_00010.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_02_00011.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_02_00012.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_02_00013.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_02_00014.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_02_00015.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00001.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00002.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00003.cbf
@@ -68,6 +79,11 @@ data:
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00008.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00009.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_03_00010.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_03_00011.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_03_00012.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_03_00013.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_03_00014.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_03_00015.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00001.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00002.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00003.cbf
@@ -78,3 +94,8 @@ data:
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00008.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00009.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_04_00010.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_04_00011.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_04_00012.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_04_00013.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_04_00014.cbf
+  - url: https://github.com/dials/data-files/raw/3c264ff4f5bee86ce6a7824e9667b865b2bd3147/l_cysteine/l-cyst_04_00015.cbf


### PR DESCRIPTION
Add some more CBFs to `l_cysteine_dials_output`.

These turn out to be necessary for some minimal xia2 multiple-sweep tests.