### PR TITLE
remove absolute paths from l-cysteine-dials-output

### DIFF
--- a/dials_data/definitions/l_cysteine_dials_output.yml
+++ b/dials_data/definitions/l_cysteine_dials_output.yml
@@ -17,8 +17,10 @@ description: >
   The indexed.expt and indexed.refl were generated using
   $ dials.index imported.expt strong.refl
 
-  The integrated files 11_integrated.* and 23_integrated.* were created by running xia2 on the first ten images (1° wedge) of each of the first two sweeps.
-  Intended to serve as test data for the behaviour of DIALS when there are few reflections, their provenance is documented in slightly more detail at the source repository.
+  The integrated files 11_integrated.* and 23_integrated.* were created by running xia2 on
+  the first ten images (1° wedge) of each of the first two sweeps.
+  Intended to serve as test data for the behaviour of DIALS when there are few reflections,
+  their provenance is documented in slightly more detail at the source repository.
 
 data:
   - url: https://dials.diamond.ac.uk/regression_data/l-cysteine_four_sweeps/datablock.json
@@ -35,9 +37,9 @@ data:
   - url: https://github.com/dials/data-files/raw/6c80c466777cb9cf5a14f963485364461e5a6ea5/l_cysteine_integrated/30_integrated_experiments.json
   - url: https://github.com/dials/data-files/raw/6c80c466777cb9cf5a14f963485364461e5a6ea5/l_cysteine_integrated/35_integrated.pickle
   - url: https://github.com/dials/data-files/raw/6c80c466777cb9cf5a14f963485364461e5a6ea5/l_cysteine_integrated/35_integrated_experiments.json
-  - url: https://github.com/dials/data-files/raw/695fa34615ec0d8cef28c8a8075ac35a193182e0/l_cysteine_narrow_wedge/11_integrated.expt
+  - url: https://github.com/dials/data-files/raw/71e13e5e4721cf34616d1f079df74b24fc170a9f/l_cysteine_narrow_wedge/11_integrated.expt
   - url: https://github.com/dials/data-files/raw/695fa34615ec0d8cef28c8a8075ac35a193182e0/l_cysteine_narrow_wedge/11_integrated.refl
-  - url: https://github.com/dials/data-files/raw/695fa34615ec0d8cef28c8a8075ac35a193182e0/l_cysteine_narrow_wedge/23_integrated.expt
+  - url: https://github.com/dials/data-files/raw/71e13e5e4721cf34616d1f079df74b24fc170a9f/l_cysteine_narrow_wedge/23_integrated.expt
   - url: https://github.com/dials/data-files/raw/695fa34615ec0d8cef28c8a8075ac35a193182e0/l_cysteine_narrow_wedge/23_integrated.refl
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00001.cbf
   - url: https://github.com/dials/data-files/raw/621009755e1f6dcaf7c1d1275d31b8af9efa70e5/l_cysteine/l-cyst_01_00002.cbf


### PR DESCRIPTION
`.expt` files referred to a `/home/...` directory, which is not accessible,
leading to errors when loading the experiments. This changes the file
reference to be relative and removes the mask reference entirely.