### PR TITLE
Add tarfile support

### DIFF
--- a/dials_data/definitions/spring8_ccp4_2018.yml
+++ b/dials_data/definitions/spring8_ccp4_2018.yml
@@ -1,0 +1,23 @@
+name: Raw X-ray diffraction images from CCP4 SPring-8 school 2018
+author: Hasegawa, Kazuya; Mizuno, Nobuhiro (2018)
+license: CC-BY 4.0
+url: https://doi.org/10.5281/zenodo.1443110
+description: >
+  Raw X-ray diffraction images collected in the beamline training in day 2 of
+  CCP4 SPring-8 school 2018
+  http://www.ccp4.ac.uk/schools/Japan-2018/program.php
+  On BL41XU, fine/coarse phi-slicing and radiation damage were demonstrated using
+  thermolysin crystals. Datasets were collected using EIGER X 16M detector at 1.2824 Å
+  wavelength. Beam size was 37.0 × 23.0 μm2. Here data from group 2 are available. See
+  an Excel file for experimental conditions. Briefly, oscillation steps of 1° (data03)
+  and 0.1° (data01) were tested under a total dose of 0.4 MGy, and radiation damage at
+  100 MGy (data02) and 10 MGy (data04) was demonstrated. You may also want to try
+  phasing by Zn-SAD? For our EIGER data file format please look at
+  https://github.com/keitaroyam/yamtbx/blob/master/doc/eiger-en.md
+
+data:
+ - url: https://zenodo.org/record/1443110/files/ccp4school2018_bl41xu_data03.tar.xz
+   files:
+   - ccp4school2018_bl41xu/05/data03/data03_master.h5
+   - ccp4school2018_bl41xu/05/data03/data03_data_000001.h5
+   - ccp4school2018_bl41xu/05/data03/data03_data_000002.h5

--- a/dials_data/download.py
+++ b/dials_data/download.py
@@ -207,10 +207,11 @@ def _fetch_filelist(filelist, file_hash):
                 # files from the archive, then we need to decompress the tar archive
                 print(f"Decompressing {source['file']}")
                 with tarfile.open(source["file"].strpath) as tar:
-                    tar.extractall(path=source["file"].dirname)
-                for f in source["files"]:
-                    if not (target_dir / f).check(file=1):
-                        print(f"Expected file {f} not present in tar archive {source['file']}")
+                    for f in source["files"]:
+                        try:
+                            tar.extract(f, path=source["file"].dirname)
+                        except KeyError:
+                            print(f"Expected file {f} not present in tar archive {source['file']}")
 
 
 class DataFetcher:

--- a/dials_data/download.py
+++ b/dials_data/download.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import contextlib
 import os
+import tarfile
 
 import dials_data.datasets
 from six.moves.urllib.request import urlopen
@@ -179,6 +180,12 @@ def _fetch_filelist(filelist, file_hash):
             if not valid:
                 print("Downloading {}".format(source["url"]))
                 _download_to_file(source["url"], source["file"])
+
+                # If the file is a tar archive, then decompress
+                if tarfile.is_tarfile(source["file"]):
+                    print(f"Decompressing {source['file']}")
+                    with tarfile.open(source["file"]) as tar:
+                        tar.extractall(path=source["file"].dirname)
 
             # verify
             valid = True

--- a/dials_data/download.py
+++ b/dials_data/download.py
@@ -205,13 +205,16 @@ def _fetch_filelist(filelist, file_hash):
             if downloaded or not all((target_dir / f).check(file=1) for f in source["files"]):
                 # If the file has been (re)downloaded, or we don't have all the requested
                 # files from the archive, then we need to decompress the tar archive
-                print(f"Decompressing {source['file']}")
+                print("Decompressing {file}".format(file=source['file']))
                 with tarfile.open(source["file"].strpath) as tar:
                     for f in source["files"]:
                         try:
                             tar.extract(f, path=source["file"].dirname)
                         except KeyError:
-                            print(f"Expected file {f} not present in tar archive {source['file']}")
+                            print(
+                                "Expected file {file} not present in tar archive {tarfile}".format(
+                                    file=f, tarfile=source["file"])
+                            )
 
 
 class DataFetcher:

--- a/dials_data/download.py
+++ b/dials_data/download.py
@@ -178,9 +178,11 @@ def _fetch_filelist(filelist, file_hash):
                             "hash", source["verify"]["hash"], file_hash(source["file"])
                         )
 
+            downloaded = False
             if not valid:
                 print("Downloading {}".format(source["url"]))
                 _download_to_file(source["url"], source["file"])
+                downloaded = True
 
             # verify
             valid = True
@@ -200,8 +202,9 @@ def _fetch_filelist(filelist, file_hash):
         # If the file is a tar archive, then decompress
         if source["files"]:
             target_dir = source["file"].dirpath()
-            if not all((target_dir / f).check(file=1) for f in source["files"]):
-                # Need to decompress the tar archive
+            if downloaded or not all((target_dir / f).check(file=1) for f in source["files"]):
+                # If the file has been (re)downloaded, or we don't have all the requested
+                # files from the archive, then we need to decompress the tar archive
                 print(f"Decompressing {source['file']}")
                 with tarfile.open(source["file"].strpath) as tar:
                     tar.extractall(path=source["file"].dirname)


### PR DESCRIPTION
Two alternative implementations of adding tarfile support:
1. Decompress tarfiles immediately after downloading, before validation of the downloaded file (17484f2)
2. Require a list of expected tar file contents to be defined in the definition.yml. After validation of the downloaded tarfile, then check the whether all expected files `source["files"]` exist locally, and if not, decompress the tarfile (0429b7e)

Minimal definition for 1. would be:
```
data:
 - url: https://zenodo.org/record/1443110/files/ccp4school2018_bl41xu_data03.tar.xz
```

Whereas for 2. more information is required:
```
data:
 - url: https://zenodo.org/record/1443110/files/ccp4school2018_bl41xu_data03.tar.xz
   files:
   - ccp4school2018_bl41xu/05/data03/data03_master.h5
   - ccp4school2018_bl41xu/05/data03/data03_data_000001.h5
   - ccp4school2018_bl41xu/05/data03/data03_data_000002.h5
```
Fixes #11, fixes #12 