### PR TITLE
Hint that every command provides individual --help

### DIFF
--- a/dials_data/cli.py
+++ b/dials_data/cli.py
@@ -119,6 +119,10 @@ def main():
 The most commonly used commands are:
    list     List available datasets
    get      Download datasets
+
+Each command has its own set of parameters, and you can get more information
+by running dials.data <command> --help
+
 """.format(
             version=version
         ),


### PR DESCRIPTION
Changes output of `dials.data --help` like this:
```patch
 usage: dials.data <command> [<args>]

 DIALS regression data manager v2.1.12-g589a0f7

 The most commonly used commands are:
    list     List available datasets
    get      Download datasets
+
+Each command has its own set of parameters, and you can get more information
+by running dials.data <command> --help

 optional arguments:
   -h, --help  show this help message and exit
```