### PR TITLE
drop mock dependency

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,5 @@
 bump2version==1.0.0
 importlib_resources>=1.1
-mock==3.0.5
 pip==20.2.2
 py==1.9.0
 pytest==6.0.1

--- a/tests/test_dials_data.py
+++ b/tests/test_dials_data.py
@@ -1,7 +1,7 @@
 import dials_data
 import dials_data.datasets
 import dials_data.download
-import mock
+from unittest import mock
 
 
 def test_all_datasets_can_be_parsed():


### PR DESCRIPTION
We don't use any features that are not already part of the 3.6+ standard library version

Closes #228