### PR TITLE
Start supporting pathlib.Path() objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,18 +52,15 @@ Installation
 
 To install this package in a normal Python environment, run::
 
-    install dials_data
+    pip install dials_data
 
 and then you can use it with::
 
     dials.data
 
-To install ``dials_data`` in a DIALS installation you need to run::
+If you are in a conda environment you can instead run::
 
-    libtbx.pip install dials_data
-
-followed by a run of either ``libtbx.configure`` or ``make reconf``
-to get access to the command line tool.
+    conda install -c conda-forge dials_data
 
 For more details please take a look at the
 `installation and usage page <https://dials-data.readthedocs.io/en/latest/installation.html>`__.

--- a/dials_data/download.py
+++ b/dials_data/download.py
@@ -1,9 +1,9 @@
 import contextlib
 import os
 import tarfile
+from pathlib import Path
 from urllib.request import urlopen
 from urllib.parse import urlparse
-
 import dials_data.datasets
 
 fcntl, msvcrt = None, None
@@ -250,18 +250,39 @@ class DataFetcher:
         """
         return result
 
-    def __call__(self, test_data, **kwargs):
+    def __call__(self, test_data, pathlib=None, **kwargs):
         """
         Return the location of a dataset, transparently downloading it if
         necessary and possible.
         The return value can be manipulated by overriding the result_filter
         function.
         :param test_data: name of the requested dataset.
-        :return: A py.path.local object pointing to the dataset, or False
+        :param pathlib: Whether to return the result as a Python pathlib object.
+                        The default for this setting is 'False' for now (leading
+                        to a py.path.local object being returned), but the default
+                        will change to 'True' in a future dials.data release.
+                        Set to 'True' for forward compatibility.
+        :return: A pathlib or py.path.local object pointing to the dataset, or False
                  if the dataset is not available.
         """
         if test_data not in self._cache:
             self._cache[test_data] = self._attempt_fetch(test_data, **kwargs)
+        # TODO: Enable deprecation warning here and in the related test
+        # if pathlib is None:
+        #    warnings.warn(
+        #        "The DataFetcher currently returns py.path.local() objects. "
+        #        "This will in the future change to pathlib.Path() objects. "
+        #        "You can either add a pathlib=True argument to obtain a pathlib.Path() object, "
+        #        "or pathlib=False to silence this warning for now.",
+        #        DeprecationWarning,
+        #        stacklevel=2,
+        #    )
+        if pathlib and self._cache[test_data]["result"]:
+            result = {
+                **self._cache[test_data],
+                "result": Path(self._cache[test_data]["result"]),
+            }
+            return self.result_filter(**result)
         return self.result_filter(**self._cache[test_data])
 
     def _attempt_fetch(self, test_data):

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,16 +28,11 @@ However you do not need to install ``dials_data`` from source. You can simply ru
 
     pip install -U dials_data
 
-or, in a cctbx/DIALS environment::
+or, in a conda environment::
 
-    libtbx.pip install -U dials_data
+    conda install -c conda-forge dials_data
 
 This will install or update an existing installation of ``dials_data``.
-
-In a cctbx/DIALS environment you may have to do a round of
-``libtbx.configure`` or ``make reconf`` to enable the ``dials_data``
-command line utilities.
-In a normal Python environment this is not required.
 
 You can then run your tests as usual using::
 
@@ -54,7 +49,7 @@ to actually enable those tests depending on files from ``dials_data``.
 As a developer to write tests with ``dials_data``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Install ``dials_data`` using ``pip`` as above.
+Install ``dials_data`` as above.
 
 If your test is written in pytest and you use the fixture provided by
 ``dials_data`` then you can use regression datasets in your test by
@@ -75,6 +70,13 @@ the test is skipped.
 The return value (``location``) is a ``py.path.local`` object pointing
 to the directory containing the requested dataset.
 
+To get a python ``pathlib.Path`` object instead you can call::
+
+.. code-block:: python
+
+    def test_accessing_a_dataset(dials_data):
+        location = dials_data("x4wide", pathlib=True)
+
 You can see a list of all available datasets by running::
 
     dials.data list
@@ -91,7 +93,7 @@ dummy fixture to your ``conftest.py``, for example:
     import pytest
     try:
         import dials_data as _  # noqa: F401
-    except ImportError:
+    except ModuleNotFoundError:
         @pytest.fixture(scope="session")
         def dials_data():
             pytest.skip("Test requires python package dials_data")
@@ -126,19 +128,13 @@ have to run::
 
     python setup.py develop
 
-or in a cctbx/DIALS environment::
-
-    libtbx.python setup.py develop
-
-followed by a round of ``libtbx.configure`` or ``make reconf``.
 This will update your python package index and install/update any
 ``dials_data`` dependencies if necessary.
 
 To switch back from using your checked out version to the 'official'
 version of ``dials_data`` you can uninstall it with::
 
-    pip uninstall dials_data # or
-    libtbx.pip uninstall dials_data
+    pip uninstall dials_data
 
 and then reinstall it following the
 `instructions at the top of this page <basic-installation_>`__.

--- a/tests/test_dials_data.py
+++ b/tests/test_dials_data.py
@@ -1,7 +1,9 @@
 import dials_data
 import dials_data.datasets
 import dials_data.download
+import pathlib
 from unittest import mock
+import py
 
 
 def test_all_datasets_can_be_parsed():
@@ -24,3 +26,49 @@ def test_requests_for_future_datasets_can_be_intercepted():
     df.result_filter.return_value = False
     assert df("aardvark") is False
     df.result_filter.assert_called_once_with(result=False)
+
+
+@mock.patch("dials_data.datasets.repository_location")
+@mock.patch("dials_data.download.fetch_dataset")
+def test_datafetcher_constructs_py_path(fetcher, root):
+    root.return_value = py.path.local("/tmp/root")
+    fetcher.return_value = True
+
+    df = dials_data.download.DataFetcher(read_only=True)
+    # TODO: Enable deprecation warning test here
+    # with pytest.warns(DeprecationWarning):
+    ds = df("dataset")
+    assert ds == py.path.local("/tmp/root/dataset")
+    assert isinstance(ds, py.path.local)
+    fetcher.assert_called_once_with(
+        "dataset", pre_scan=True, read_only=False, download_lockdir=mock.ANY
+    )
+
+    ds = df("dataset", pathlib=False)
+    assert ds == py.path.local("/tmp/root/dataset")
+    assert isinstance(ds, py.path.local)
+    fetcher.assert_called_once()
+
+
+@mock.patch("dials_data.datasets.repository_location")
+@mock.patch("dials_data.download.fetch_dataset")
+def test_datafetcher_constructs_path(fetcher, root):
+    root.return_value = py.path.local("/tmp/root")
+    fetcher.return_value = True
+
+    df = dials_data.download.DataFetcher(read_only=True)
+    ds = df("dataset", pathlib=True)
+    assert ds == pathlib.Path("/tmp/root/dataset")
+    assert isinstance(ds, pathlib.Path)
+    fetcher.assert_called_once_with(
+        "dataset", pre_scan=True, read_only=False, download_lockdir=mock.ANY
+    )
+
+    ds = df("dataset")
+    assert ds == pathlib.Path("/tmp/root/dataset")
+    assert not isinstance(
+        ds, pathlib.Path
+    )  # default is currently to return py.path.local()
+    fetcher.assert_called_once_with(
+        "dataset", pre_scan=True, read_only=False, download_lockdir=mock.ANY
+    )


### PR DESCRIPTION
Instead of providing `py.path.local()` objects add a facility to provide
`pathlib.Path()` objects.
Update tests and the documentation accordingly.

Don't add a `DeprecationWarning` yet for backward compatibility with older
`dials_data` versions installed on developer machines.