### PR TITLE
Begin deprecation of `py.path` usage

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.2.0
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,18 @@
 History
 =======
 
+2.2 (2021-06-18)
+^^^^^^^^^^^^^^^^
+
+* Deprecate the use of ``py.path`` as test fixture return type.
+  You can either silence the warning by specifying ``dials_data("dataset", pathlib=False)``
+  or move to the new ``pathlib.Path`` return objects by setting ``pathlib=True``.
+  This deprecation is planned to be in place for a considerable amount of time.
+  In the next major release (3.0) the default return type will become ``pathlib.Path``,
+  with ``py.path`` still available if ``pathlib=False`` is specified. At this point
+  the ``pathlib=`` argument will be deprecated.
+  In the following minor release (3.1) all support for ``py.path`` will be dropped.
+
 2.1 (2020-06-11)
 ^^^^^^^^^^^^^^^^
 

--- a/dials_data/__init__.py
+++ b/dials_data/__init__.py
@@ -6,6 +6,6 @@ https://github.com/dials/data
 __all__ = []
 __author__ = """Markus Gerstel"""
 __email__ = "dials-support@lists.sourceforge.net"
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 __commit__ = ""
 __version_tuple__ = tuple(int(x) for x in __version__.split("."))

--- a/dials_data/download.py
+++ b/dials_data/download.py
@@ -2,6 +2,7 @@ import contextlib
 import errno
 import os
 import tarfile
+import warnings
 from pathlib import Path
 from urllib.request import urlopen
 from urllib.parse import urlparse
@@ -278,16 +279,15 @@ class DataFetcher:
         """
         if test_data not in self._cache:
             self._cache[test_data] = self._attempt_fetch(test_data, **kwargs)
-        # TODO: Enable deprecation warning here and in the related test
-        # if pathlib is None:
-        #    warnings.warn(
-        #        "The DataFetcher currently returns py.path.local() objects. "
-        #        "This will in the future change to pathlib.Path() objects. "
-        #        "You can either add a pathlib=True argument to obtain a pathlib.Path() object, "
-        #        "or pathlib=False to silence this warning for now.",
-        #        DeprecationWarning,
-        #        stacklevel=2,
-        #    )
+        if pathlib is None:
+            warnings.warn(
+                "The DataFetcher currently returns py.path.local() objects. "
+                "This will in the future change to pathlib.Path() objects. "
+                "You can either add a pathlib=True argument to obtain a pathlib.Path() object, "
+                "or pathlib=False to silence this warning for now.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if pathlib and self._cache[test_data]["result"]:
             result = {
                 **self._cache[test_data],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ author = "Markus Gerstel"
 # the built documents.
 #
 # The short X.Y version.
-version = "2.1.0"
+version = "2.2.0"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -58,7 +58,7 @@ adding the ``dials_data`` fixture to your test, ie:
 .. code-block:: python
 
     def test_accessing_a_dataset(dials_data):
-        location = dials_data("x4wide")
+        location = dials_data("x4wide", pathlib=True)
 
 The fixture/variable ``dials_data`` in the test is a
 ``dials_data.download.DataFetcher`` instance, which can be called with
@@ -67,15 +67,19 @@ files are not present on the machine then they will be downloaded.
 If either the download fails or ``--regression`` is not specified then
 the test is skipped.
 
-The return value (``location``) is a ``py.path.local`` object pointing
+The return value (``location``) is a ``pathlib.Path`` object pointing
 to the directory containing the requested dataset.
 
-To get a python ``pathlib.Path`` object instead you can call:
+To get a python ``py.path.local`` object instead you can call:
 
 .. code-block:: python
 
     def test_accessing_a_dataset(dials_data):
-        location = dials_data("x4wide", pathlib=True)
+        location = dials_data("x4wide", pathlib=False)
+
+However, please note that the ``py.path`` support is deprecated, and
+will be removed at some point in the future. Currently, if you do not
+specify the ``pathlib=`` argument a ``py.path`` object is returned.
 
 You can see a list of all available datasets by running::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dials_data
-version = 2.1.0
+version = 2.2.0
 url = https://github.com/dials/data
 project_urls =
     Bug Tracker = https://github.com/dials/data/issues

--- a/tests/test_dials_data.py
+++ b/tests/test_dials_data.py
@@ -4,6 +4,7 @@ import dials_data.download
 import pathlib
 from unittest import mock
 import py
+import pytest
 
 
 def test_all_datasets_can_be_parsed():
@@ -35,9 +36,8 @@ def test_datafetcher_constructs_py_path(fetcher, root):
     fetcher.return_value = True
 
     df = dials_data.download.DataFetcher(read_only=True)
-    # TODO: Enable deprecation warning test here
-    # with pytest.warns(DeprecationWarning):
-    ds = df("dataset")
+    with pytest.warns(DeprecationWarning):
+        ds = df("dataset")
     assert ds == py.path.local("/tmp/root/dataset")
     assert isinstance(ds, py.path.local)
     fetcher.assert_called_once_with(


### PR DESCRIPTION
`py.path` has been deprecated (rather: ["_in maintenance mode_"](https://py.readthedocs.io/en/latest/path.html)) for a long time, and since we moved to Python 3 there is no reason now to not use the standard library [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html) objects.

This commit enables a `DeprecationWarning` when the pytest fixture does not specify a preferred return object type.

A deprecation plan is laid out in `HISTORY.rst`