### PR TITLE
Add pycbf test data

### DIFF
--- a/dials_data/definitions/image_examples.yml
+++ b/dials_data/definitions/image_examples.yml
@@ -19,3 +19,4 @@ data:
   - url: https://github.com/dials/data-files/raw/9ecf5a4e6d36a2c77574178d306292dd1c093359/image_examples/Gatan_float32_zero_array_001.dm4.gz
   - url: https://github.com/dials/data-files/raw/f587a81ac82b3c35a757492e92259a0105ee1c2a/image_examples/SACLA-MPCCD-run266702-0-subset-refined_experiments_level1.json
   - url: https://github.com/dials/data-files/raw/f587a81ac82b3c35a757492e92259a0105ee1c2a/image_examples/SACLA-MPCCD-run266702-0-subset.h5
+  - url: https://github.com/dials/data-files/raw/2fc35b473ea4a9c68279e438d4e39e2662d9dfdb/image_examples/endonat3_001.mar2300

--- a/dials_data/definitions/pycbf.yml
+++ b/dials_data/definitions/pycbf.yml
@@ -1,0 +1,8 @@
+name: pycbf
+description: >
+    pycbf test data files.
+
+data:
+  - https://github.com/dials/data-files/raw/2fc35b473ea4a9c68279e438d4e39e2662d9dfdb/pycbf/adscconverted.cbf
+  - https://github.com/dials/data-files/raw/2fc35b473ea4a9c68279e438d4e39e2662d9dfdb/pycbf/img2cif_packed.cbf
+  - https://github.com/dials/data-files/raw/2fc35b473ea4a9c68279e438d4e39e2662d9dfdb/image_examples/endonat3_001.mar2300


### PR DESCRIPTION
Add the pycbf test files. This includes a sample mar345 image, which has been added to the image_examples definition.