### PR TITLE
Bump version: 2.2.0 → 2.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.0
+current_version = 2.3.0
 commit = True
 tag = True
 

--- a/dials_data/__init__.py
+++ b/dials_data/__init__.py
@@ -8,6 +8,6 @@ from __future__ import annotations
 __all__: list = []
 __author__ = """Markus Gerstel"""
 __email__ = "dials-support@lists.sourceforge.net"
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 __commit__ = ""
 __version_tuple__ = tuple(int(x) for x in __version__.split("."))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ author = "Markus Gerstel"
 # the built documents.
 #
 # The short X.Y version.
-version = "2.2.0"
+version = "2.3.0"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dials_data
-version = 2.2.0
+version = 2.3.0
 url = https://github.com/dials/data
 project_urls =
     Bug Tracker = https://github.com/dials/data/issues


### PR DESCRIPTION
Minor version increase because of Python 3.6 EOL and dataset rename