### PR TITLE
Correct typo in pathlib.Path.is_file method call

### DIFF
--- a/dials_data/download.py
+++ b/dials_data/download.py
@@ -231,7 +231,7 @@ def _fetch_filelist(filelist: list[dict[str, Any]], file_hash) -> None:
         if source["files"]:
             target_dir = source["file"].parent
             if downloaded or not all(
-                (target_dir / f).is_fire() for f in source["files"]
+                (target_dir / f).is_file() for f in source["files"]
             ):
                 # If the file has been (re)downloaded, or we don't have all the requested
                 # files from the archive, then we need to decompress the archive


### PR DESCRIPTION
Unless I'm mistaken, this looks like the intended method call.  @Anthchirp, I'm not sure exactly what this does, nor how to test for the correct behaviour.