### PR TITLE
Remove 'lockdir' parameter

### DIFF
--- a/tests/test_dials_data.py
+++ b/tests/test_dials_data.py
@@ -44,9 +44,7 @@ def test_datafetcher_constructs_py_path(fetcher, root):
         ds = df("dataset")
     assert pathlib.Path(ds).resolve() == pathlib.Path("/tmp/root/dataset").resolve()
     assert isinstance(ds, py.path.local)
-    fetcher.assert_called_once_with(
-        "dataset", pre_scan=True, read_only=False, download_lockdir=mock.ANY
-    )
+    fetcher.assert_called_once_with("dataset", pre_scan=True, read_only=False)
 
     ds = df("dataset", pathlib=False)
     assert pathlib.Path(ds).resolve() == pathlib.Path("/tmp/root/dataset").resolve()
@@ -66,9 +64,7 @@ def test_datafetcher_constructs_path(fetcher, root):
     assert ds == test_path / "dataset"
 
     assert isinstance(ds, pathlib.Path)
-    fetcher.assert_called_once_with(
-        "dataset", pre_scan=True, read_only=False, download_lockdir=mock.ANY
-    )
+    fetcher.assert_called_once_with("dataset", pre_scan=True, read_only=False)
 
     with pytest.warns(DeprecationWarning):
         ds = df("dataset")
@@ -76,6 +72,4 @@ def test_datafetcher_constructs_path(fetcher, root):
     assert not isinstance(
         ds, pathlib.Path
     )  # default is currently to return py.path.local()
-    fetcher.assert_called_once_with(
-        "dataset", pre_scan=True, read_only=False, download_lockdir=mock.ANY
-    )
+    fetcher.assert_called_once_with("dataset", pre_scan=True, read_only=False)


### PR DESCRIPTION
this is redundant, as this is the target directory (when read-only=False) or nothing (when read-only=True)