### PR TITLE
Update data set four_circle_eiger to match Zenodo

### DIFF
--- a/dials_data/definitions/four_circle_eiger.yml
+++ b/dials_data/definitions/four_circle_eiger.yml
@@ -25,19 +25,19 @@ description: >
     CuHF2pyz2PF6b_P_O_02.nxs — a 600-image 120° ω scan.
   
 data:
-  - url: https://zenodo.org/record/6093231/files/01_CuHF2pyz2PF6b_Phi.tar.xz
+  - url: https://zenodo.org/record/6344069/files/01_CuHF2pyz2PF6b_Phi.tar.xz
     files:
       - 01_CuHF2pyz2PF6b_Phi/CuHF2pyz2PF6b_Phi_01_000001.h5
       - 01_CuHF2pyz2PF6b_Phi/CuHF2pyz2PF6b_Phi_01_000002.h5
       - 01_CuHF2pyz2PF6b_Phi/CuHF2pyz2PF6b_Phi_01_meta.h5
       - 01_CuHF2pyz2PF6b_Phi/CuHF2pyz2PF6b_Phi_01.nxs
-  - url: https://zenodo.org/record/6093231/files/02_CuHF2pyz2PF6b_2T.tar.xz
+  - url: https://zenodo.org/record/6344069/files/02_CuHF2pyz2PF6b_2T.tar.xz
     files:
       - 02_CuHF2pyz2PF6b_2T/CuHF2pyz2PF6b_2T_01_000001.h5
       - 02_CuHF2pyz2PF6b_2T/CuHF2pyz2PF6b_2T_01_000002.h5
       - 02_CuHF2pyz2PF6b_2T/CuHF2pyz2PF6b_2T_01_meta.h5
       - 02_CuHF2pyz2PF6b_2T/CuHF2pyz2PF6b_2T_01.nxs
-  - url: https://zenodo.org/record/6093231/files/03_CuHF2pyz2PF6b_P_O.tar.xz
+  - url: https://zenodo.org/record/6344069/files/03_CuHF2pyz2PF6b_P_O.tar.xz
     files:
       - 03_CuHF2pyz2PF6b_P_O/CuHF2pyz2PF6b_P_O_01_000001.h5
       - 03_CuHF2pyz2PF6b_P_O/CuHF2pyz2PF6b_P_O_01_000002.h5


### PR DESCRIPTION
A new version of this data set has been uploaded to Zenodo.  In this new
version, the data set `/entry/instrument/detector_distance` has been
renamed to `/entry/instrument/detector/distance`.