### PR TITLE
Add reference PDB model to cunir_serial definition

### DIFF
--- a/dials_data/definitions/cunir_serial.yml
+++ b/dials_data/definitions/cunir_serial.yml
@@ -4,6 +4,7 @@ license: CC-BY 4.0
 description: >
   5 example SSX images of CuNiR, taken on I24 beamline at Diamond
   Light Source.
+  Also provided is a reference PDB structure for this protein (pdb entry 2BW4).
 
 data:
   - url: https://github.com/dials/data-files/raw/a0e40127492faa165a9f5ef7590ff1591957e6d9/ssx_CuNiR_test_data/merlin0047_17000.cbf
@@ -11,3 +12,4 @@ data:
   - url: https://github.com/dials/data-files/raw/a0e40127492faa165a9f5ef7590ff1591957e6d9/ssx_CuNiR_test_data/merlin0047_17002.cbf
   - url: https://github.com/dials/data-files/raw/a0e40127492faa165a9f5ef7590ff1591957e6d9/ssx_CuNiR_test_data/merlin0047_17003.cbf
   - url: https://github.com/dials/data-files/raw/a0e40127492faa165a9f5ef7590ff1591957e6d9/ssx_CuNiR_test_data/merlin0047_17004.cbf
+  - url: https://files.rcsb.org/download/2BW4.pdb


### PR DESCRIPTION
Required for testing data reduction workflows for SSX data