### PR TITLE
Don't use permission flags from tar archives

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ History
 2.5 (????-??-??)
 ^^^^^^^^^^^^^^^^
 
+* Fix permission generation when extracting tar archives. Files extracted will be created with
+  default permissions, instead of what has been packed in with the archive. This solves the issue
+  of shared data stores becoming inaccessible to some users.
 
 2.4 (2022-03-07)
 ^^^^^^^^^^^^^^^^

--- a/dials_data/download.py
+++ b/dials_data/download.py
@@ -250,7 +250,7 @@ def _fetch_file(
                 with tarfile.open(source["file"]) as tar:
                     for f in source["files"]:
                         try:
-                            tar.extract(f, path=source["file"].parent)
+                            tar.extract(f, path=source["file"].parent, set_attrs=False)
                         except KeyError:
                             print(
                                 f"Expected file {f} not present "


### PR DESCRIPTION
If the creator saved uid/gid/permissions into the tar archive, this could cause a warning (not being able to set uid/gid), but could also overwrite the intended permissions of the destination path with those inside the archive.

This cause an issue at Diamond where one of the data sets encoded `0o660` instead of inheriting from the directory `0o664`, which meant the data was not accessible by other users.