### PR TITLE
Add 4fluoro dataset for testing cctbx.xfel.small_cell

### DIFF
--- a/dials_data/definitions/4fluoro_cxi.yml
+++ b/dials_data/definitions/4fluoro_cxi.yml
@@ -1,0 +1,42 @@
+name: 4-fluoro dataset for 2022 LCLS smSFX workshop
+author: Aaron Brewster, Daniel Paley, Elyse Schriber, Vanessa Oklejas, David Moreau, and J. Nathan Hohman
+license: CC-BY 4.0
+url: https://doi.org/10.5281/zenodo.7117518
+description: >
+ This is the dataset for the 2022 LCLS user meeting workshop, "Applications for small-molecule Serial Femtosecond Diffraction in Materials Science and Chemistry"
+
+ For full details, please refer to the full set of data processing instructions here:
+ https://docs.google.com/document/d/1UNz3zTATIak5UkVGIli0W3HjHZr9orBiWp4nt12AzOQ
+
+ The dataset contains these folders:
+
+ - calibration: calibration constants needed for indexing
+   - r0215.expt: refined geometry file for the JF4M detector
+   - psana_border_hot_shift4.mask: untrusted pixel mask
+ - spotfinding:
+   - r0165_strong.expt, r0165_strong.refl: spotfinding results for run 165
+   - 4fluoro_peaks.txt: a list of 20 peaks harvested from the spotfinder powder pattern.
+ - ten_cbfs: 10 cbf files of 4-fluoro, created from LCLS experiment LY65, run 164.
+ - indexing: working folder for indexing the 10 cbfs.  Contains params_1.phil file, the indexing parameters for cctbx.small_cell_process
+ - merging: data folders, one per run, with integrated.expt and integrated.refl files
+   - mark1.phil and mark0.phil: phil parameters for merging
+ - refinement: 4fluoro_final.res, 4fluoro.hkl, 4fluoro_solved1.res, 4fluoro_solved2.res, 4fluoro_start.ins, input and output files for solving and refining the 4fluoro structure
+
+data:
+  - url: https://zenodo.org/record/7117519/files/lcls_2022_smSFX_workshop_data.tar.gz
+    files:
+      - lcls_2022_smSFX_workshop_data/calibration/psana_border_hot_shift4.mask
+      - lcls_2022_smSFX_workshop_data/calibration/r0215.expt
+      - lcls_2022_smSFX_workshop_data/indexing/params_1.phil
+      - lcls_2022_smSFX_workshop_data/spotfinding/r0165_strong.expt
+      - lcls_2022_smSFX_workshop_data/spotfinding/r0165_strong.refl
+      - lcls_2022_smSFX_workshop_data/ten_cbfs/cxily6520_r0164_02081.cbf
+      - lcls_2022_smSFX_workshop_data/ten_cbfs/cxily6520_r0164_08320.cbf
+      - lcls_2022_smSFX_workshop_data/ten_cbfs/cxily6520_r0164_15949.cbf
+      - lcls_2022_smSFX_workshop_data/ten_cbfs/cxily6520_r0164_43630.cbf
+      - lcls_2022_smSFX_workshop_data/ten_cbfs/cxily6520_r0164_45478.cbf
+      - lcls_2022_smSFX_workshop_data/ten_cbfs/cxily6520_r0164_05021.cbf
+      - lcls_2022_smSFX_workshop_data/ten_cbfs/cxily6520_r0164_10738.cbf
+      - lcls_2022_smSFX_workshop_data/ten_cbfs/cxily6520_r0164_42048.cbf
+      - lcls_2022_smSFX_workshop_data/ten_cbfs/cxily6520_r0164_44166.cbf
+      - lcls_2022_smSFX_workshop_data/ten_cbfs/cxily6520_r0164_67542.cbf


### PR DESCRIPTION
Dataset is 250 MB compressed.  Won't be used by dials pytests, but will be used by xfel_regression tests.

We liked how dials.data uses zenodo so we wanted to put this here instead of xfel_regression :)

Co-authored-by: Daniel Paley <dwpaley@lbl.gov>