### PR TITLE
dials_data is repo name dials-data is package name

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -51,7 +51,7 @@ If you are proposing a feature:
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `dials_data` for local development.
+Ready to contribute? Here's how to set up `dials-data` for local development.
 
 1. Fork the `dials/data` `repository on GitHub <https://github.com/dials/data>`__.
 2. Clone your fork locally::

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ DIALS Regression Data Manager
 A python package providing data files used for regression tests in
 DIALS_, dxtbx_, xia2_ and related packages.
 
-If you want to know more about what ``dials_data`` is you can
+If you want to know more about what ``dials-data`` is you can
 have a read through the `background information <https://dials-data.readthedocs.io/en/latest/why.html>`__.
 
 For everything else `the main documentation <https://dials-data.readthedocs.io/>`__ is probably the best start.
@@ -52,7 +52,7 @@ Installation
 
 To install this package in a normal Python environment, run::
 
-    pip install dials_data
+    pip install dials-data
 
 and then you can use it with::
 
@@ -60,7 +60,7 @@ and then you can use it with::
 
 If you are in a conda environment you can instead run::
 
-    conda install -c conda-forge dials_data
+    conda install -c conda-forge dials-data
 
 For more details please take a look at the
 `installation and usage page <https://dials-data.readthedocs.io/en/latest/installation.html>`__.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -53,14 +53,14 @@ Install ``dials-data`` as above.
 
 If your test is written in pytest and you use the fixture provided by
 ``dials-data`` then you can use regression datasets in your test by
-adding the ``dials-data`` fixture to your test, ie:
+adding the ``dials_data`` fixture to your test, ie:
 
 .. code-block:: python
 
     def test_accessing_a_dataset(dials_data):
         location = dials_data("x4wide", pathlib=True)
 
-The fixture/variable ``dials-data`` in the test is a
+The fixture/variable ``dials_data`` in the test is a
 ``dials_data.download.DataFetcher`` instance, which can be called with
 the name of the dataset you want to access (here: ``x4wide``). If the
 files are not present on the machine then they will be downloaded.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,27 +4,27 @@
 Installation and Usage
 ======================
 
-There are a number of possible ways to install ``dials_data``.
+There are a number of possible ways to install ``dials-data``.
 From the simplest to the most involved these are:
 
 
 As an end user
 ^^^^^^^^^^^^^^
 
-Quite simply: You do not need to install ``dials_data``.
+Quite simply: You do not need to install ``dials-data``.
 It does not add any functionality to end users.
 
 
-As a developer to run tests with ``dials_data``
+As a developer to run tests with ``dials-data``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You may want to install ``dials_data`` so that you can run regression tests locally.
+You may want to install ``dials-data`` so that you can run regression tests locally.
 Or you might say that continuous integration should take care of this.
 Both are valid opinions.
 
 .. _basic-installation:
 
-However you do not need to install ``dials_data`` from source. You can simply run::
+However you do not need to install ``dials-data`` from source. You can simply run::
 
     pip install -U dials-data
 
@@ -32,7 +32,7 @@ or, in a conda environment::
 
     conda install -c conda-forge dials-data
 
-This will install or update an existing installation of ``dials_data``.
+This will install or update an existing installation of ``dials-data``.
 
 You can then run your tests as usual using::
 
@@ -43,24 +43,24 @@ probably need to run it as::
 
     pytest --regression
 
-to actually enable those tests depending on files from ``dials_data``.
+to actually enable those tests depending on files from ``dials-data``.
 
 
-As a developer to write tests with ``dials_data``
+As a developer to write tests with ``dials-data``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Install ``dials_data`` as above.
+Install ``dials-data`` as above.
 
 If your test is written in pytest and you use the fixture provided by
-``dials_data`` then you can use regression datasets in your test by
-adding the ``dials_data`` fixture to your test, ie:
+``dials-data`` then you can use regression datasets in your test by
+adding the ``dials-data`` fixture to your test, ie:
 
 .. code-block:: python
 
     def test_accessing_a_dataset(dials_data):
         location = dials_data("x4wide", pathlib=True)
 
-The fixture/variable ``dials_data`` in the test is a
+The fixture/variable ``dials-data`` in the test is a
 ``dials_data.download.DataFetcher`` instance, which can be called with
 the name of the dataset you want to access (here: ``x4wide``). If the
 files are not present on the machine then they will be downloaded.
@@ -89,7 +89,7 @@ or by going through the
 `dataset definition files in the repository <https://github.com/dials/data/tree/master/dials_data/definitions>`__.
 
 If you want the tests on your project to be runnable even when
-``dials_data`` is not installed in the environment you could add a
+``dials-data`` is not installed in the environment you could add a
 dummy fixture to your ``conftest.py``, for example:
 
 .. code-block:: python
@@ -103,24 +103,24 @@ dummy fixture to your ``conftest.py``, for example:
             pytest.skip("Test requires python package dials_data")
 
 
-As a developer who wants to add files to ``dials_data``
+As a developer who wants to add files to ``dials-data``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Follow the steps in :doc:`/contributing` to install ``dials_data`` into a
+Follow the steps in :doc:`/contributing` to install ``dials-data`` into a
 virtual environment.
 
-You can install ``dials_data`` using ``pip`` as above *unless* you want to
+You can install ``dials-data`` using ``pip`` as above *unless* you want to
 immediately use your dataset definition in tests without waiting for your
 pull request to be accepted. In this case you can follow the instructions
 in the next step.
 
 
-As a developer who wants to extend ``dials_data``
+As a developer who wants to extend ``dials-data``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Have a look at the :doc:`/contributing` page.
 
-Install your own fork of ``dials_data`` by running::
+Install your own fork of ``dials-data`` by running::
 
     pip install -e path/to/fork
 
@@ -133,12 +133,12 @@ have to run::
     python setup.py develop
 
 This will update your python package index and install/update any
-``dials_data`` dependencies if necessary.
+``dials-data`` dependencies if necessary.
 
 To switch back from using your checked out version to the 'official'
-version of ``dials_data`` you can uninstall it with::
+version of ``dials-data`` you can uninstall it with::
 
-    pip uninstall dials_data
+    pip uninstall dials-data
 
 and then reinstall it following the
 `instructions at the top of this page <basic-installation_>`__.
@@ -157,4 +157,4 @@ In order of evaluation:
   ``dials_data`` exists or can be created underneath that location then
   use that.
 * Use ``~/.cache/dials_data`` if it exists or can be created.
-* Otherwise ``dials_data`` will fail with a RuntimeError.
+* Otherwise ``dials-data`` will fail with a RuntimeError.

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -1,8 +1,8 @@
 ======================
-What is ``dials_data``
+What is ``dials-data``
 ======================
 
-``dials_data`` is a lightweight, simple python(-only) package.
+``dials-data`` is a lightweight, simple python(-only) package.
 It is used to provide access to data files used in regression tests,
 but does not contain any of those data files itself.
 
@@ -11,7 +11,7 @@ environment for tests in DIALS_, dxtbx_, xia2_ and related packages,
 it has no dependencies on either cctbx_ or DIALS_, in fact
 all dependencies are explicitly declared in the setup.py_ file and are
 installable via standard setuptools/pip methods.
-This means ``dials_data`` can easily be used in other projects accessing
+This means ``dials-data`` can easily be used in other projects accessing
 the same data, and can be used in temporary environments such as
 Travis containers.
 
@@ -52,9 +52,9 @@ needed downloading separately and could not easily be used outside
 of the dials_ repository and not at all outside of a dials_
 distribution. Adding data files was still a very involved process.
 
-``dials_data`` is the next iteration of our solution to this problem.
+``dials-data`` is the next iteration of our solution to this problem.
 
-What can ``dials_data`` do
+What can ``dials-data`` do
 ==========================
 
 The entire pipeline, from adding new data files, to the automatic


### PR DESCRIPTION
Replaced documentation references to package name `dials_data` with `dials-data` for consistency (`dials_data` is not recognised on conda). I've left references to directories and github paths as `dials_data`. Pytest fixture is also `dials_data`. I now remember why I didn't commit to pushing this earlier.