### PR TITLE
Add example integrated files from vmxi serial grid scans on DtpB.

### DIFF
--- a/dials_data/definitions/dtpb_serial_processed.yml
+++ b/dials_data/definitions/dtpb_serial_processed.yml
@@ -1,0 +1,17 @@
+name: xia2.ssx output of processing a DtpB SSX data set from VMXi
+author: James Beilsten-Edmands (2022)
+license: CC-BY 4.0
+description: >
+  Processed data from DtpB taken on VMXi beamline at Diamond Light
+  Source in Feb 2022, visit nt30330-15, courtesy of Mike Hough and James Sandy.
+
+  The integrated files were generated from xia2.ssx processing of grid
+  scans on two wells of dye-type peroxidase (DtpB). The files were generated
+  with dials version 3.12.0, as described in the entry in dials/data-files.
+  
+
+data:
+  - url: https://github.com/dials/data-files/raw/3849a695d7a136d6e93584ccefc17ef59de8c815/ssx_DtpB_test_data/well39_batch12_integrated.expt
+  - url: https://github.com/dials/data-files/raw/3849a695d7a136d6e93584ccefc17ef59de8c815/ssx_DtpB_test_data/well39_batch12_integrated.refl
+  - url: https://github.com/dials/data-files/raw/3849a695d7a136d6e93584ccefc17ef59de8c815/ssx_DtpB_test_data/well42_batch6_integrated.expt
+  - url: https://github.com/dials/data-files/raw/3849a695d7a136d6e93584ccefc17ef59de8c815/ssx_DtpB_test_data/well42_batch6_integrated.refl


### PR DESCRIPTION
This PR adds integrated data files from `xia2.ssx` processing of two VMXi serial grid scans.

The purpose is to enable testing of data reduction features on processed data originating from images in nexus/h5 format (in addition to existing tests on cbf format).