### PR TITLE
Update obsolete files

### DIFF
--- a/dials_data/definitions/centroid_test_data.yml
+++ b/dials_data/definitions/centroid_test_data.yml
@@ -24,12 +24,12 @@ data:
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/datablock.json
   - url: https://github.com/dials/data-files/raw/12c29cae96057da91a2da5c5ce042846cf9a79fa/centroid_test_data/datablock_with_bad_lookup.json
   - url: https://github.com/dials/data-files/raw/12c29cae96057da91a2da5c5ce042846cf9a79fa/centroid_test_data/datablock_with_lookup.json
-  - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/experiments.json
+  - url: https://github.com/dials/data-files/raw/3eb66b340b7ade76dd8c41abfbf6f2f83bfb846a/centroid_test_data/experiments.json
   - url: https://github.com/dials/data-files/raw/12c29cae96057da91a2da5c5ce042846cf9a79fa/centroid_test_data/experiments_with_bad_lookup.json
   - url: https://github.com/dials/data-files/raw/12c29cae96057da91a2da5c5ce042846cf9a79fa/centroid_test_data/experiments_with_lookup.json
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/fake_long_experiments.json
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/imported_experiments.json
-  - url: https://github.com/dials/data-files/raw/f18bfc49b4a086db0145097ea2cb67cf23be0835/centroid_test_data/indexed.expt
+  - url: https://github.com/dials/data-files/raw/3eb66b340b7ade76dd8c41abfbf6f2f83bfb846a/centroid_test_data/indexed.expt
   - url: https://github.com/dials/data-files/raw/f18bfc49b4a086db0145097ea2cb67cf23be0835/centroid_test_data/indexed.refl
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/integrated.pickle
   - url: https://github.com/dials/data-files/raw/a02df474ff193f102624bd08038cdc2c421dc8ee/centroid_test_data/integrated.refl

--- a/dials_data/definitions/refinement_test_data.yml
+++ b/dials_data/definitions/refinement_test_data.yml
@@ -14,6 +14,7 @@ description: >
 data:
 
   - url: https://github.com/dials/data-files/raw/d189d8ab4a6dc15e8d24b909e8d8f00c64366f1c/refinement_test_data/hierarchy_test/cspad-single-image-datablock.json
+  - url: https://github.com/dials/data-files/raw/74bbe2ca08260eb3ba51573747acc2f2673ba472/refinement_test_data/hierarchy_test/cspad-single-image.expt
   - url: https://github.com/dials/data-files/raw/d189d8ab4a6dc15e8d24b909e8d8f00c64366f1c/refinement_test_data/outlier_rejection/residuals-with-outliers.dat
   - url: https://github.com/dials/data-files/raw/d189d8ab4a6dc15e8d24b909e8d8f00c64366f1c/refinement_test_data/centroid_outlier/centroid_outlier_residuals.refl
   - url: https://github.com/dials/data-files/raw/d189d8ab4a6dc15e8d24b909e8d8f00c64366f1c/refinement_test_data/i23_as_24_panel_barrel/I23_24_panel.json


### PR DESCRIPTION
Update to newer versions of two experiment files and add an `ExperimentList` to replace a deprecated `DataBlock`

See https://github.com/dials/data-files/pull/48