### PR TITLE
Downgrade sphinx that renovate broke

### DIFF
--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,5 +1,5 @@
 py==1.11.0
 pytest==7.4.0
 pyyaml==6.0.1
-Sphinx==7.1.2
+Sphinx==6.2.1
 sphinx_rtd_theme==1.2.2


### PR DESCRIPTION
sphinx_rtd_theme is currently incompatible with sphinx 7.

Renovate doesn't care. It just blindly updates. We may need to reconsider using this tool.