### PR TITLE
Add semisynthetic multilattice data for testing indexing

### DIFF
--- a/dials_data/definitions/semisynthetic_multilattice.yml
+++ b/dials_data/definitions/semisynthetic_multilattice.yml
@@ -1,0 +1,16 @@
+name: Processed semisynthetic multilattice data
+author: James Beilsten-Edmands (2023)
+license: CC-BY 4.0
+description: >
+  Example DIALS-processed multi-lattice data.
+
+  Data from https://zenodo.org/records/10820, file
+  semisynthetic_multilattice_2.tar.bz processed
+  with DIALS 3.16 (first 50 images from datasets ag & bh).
+  Each sweep contains two crystal lattices.
+
+data:
+  - url: https://github.com/dials/data-files/raw/6e104f91736c86aa6c516f8969fa0fbebdd02c58/semisynthetic_multilattice_2/ag_imported_1_50.expt
+  - url: https://github.com/dials/data-files/raw/6e104f91736c86aa6c516f8969fa0fbebdd02c58/semisynthetic_multilattice_2/bh_imported_1_50.expt
+  - url: https://github.com/dials/data-files/raw/6e104f91736c86aa6c516f8969fa0fbebdd02c58/semisynthetic_multilattice_2/ag_strong_1_50.refl
+  - url: https://github.com/dials/data-files/raw/6e104f91736c86aa6c516f8969fa0fbebdd02c58/semisynthetic_multilattice_2/bh_strong_1_50.refl


### PR DESCRIPTION
This adds prcoessed data for the purpose of testing indexing - it contains two different sweeps, each containing two crystal lattices, so is useful for testing the most generalised case of multiple imagesets + multiple lattices per imageset.