### PR TITLE
Pin importlib_resources to avoid CI errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ keywords = dials, dials_data
 [options]
 include_package_data = True
 install_requires =
-    importlib_resources>=1.1
+    importlib_resources>=1.1,<6.2
     pytest
     pyyaml
     requests


### PR DESCRIPTION
Avoid downstream CI errors caused by https://github.com/python/importlib_resources/issues/298