### PR TITLE
add isis_sxd_nacl_processed.yml

### DIFF
--- a/dials_data/definitions/isis_sxd_nacl_processed.yml
+++ b/dials_data/definitions/isis_sxd_nacl_processed.yml
@@ -1,0 +1,12 @@
+name: Experiment geometry and strong spots for time-of-flight Laue neutron diffraction data recorded from NaCl crystals at SXD (ISIS)
+author: David McDonagh (2024)
+license: CC-BY 4.0
+url: https://doi.org/10.5281/zenodo.4415768
+description: >
+  imported.expt and strong.refl were created using DIALS 3.dev.1130-g8c524b30c
+  with the following commands:
+    $ dials.import "$(dials.data get -q isis_sxd_example_data)/sxd_nacl_run.nxs"
+    $ dials.find_spots imported.expt
+data:
+  - url: https://github.com/dials/data-files/raw/ac63f5790bbddf7292b45ae825daefdbe60f7858/isis_sxd_nacl_processed/imported.expt
+  - url: https://github.com/dials/data-files/raw/ac63f5790bbddf7292b45ae825daefdbe60f7858/isis_sxd_nacl_processed/strong.refl


### PR DESCRIPTION
Adds `isis_sxd_nacl_processed.yml` as an example of processed time-of-flight data.