### PR TITLE
Add MPCCD images reformatted as NeXus NXmx

### DIFF
--- a/dials_data/definitions/image_examples.yml
+++ b/dials_data/definitions/image_examples.yml
@@ -22,3 +22,4 @@ data:
   - url: https://github.com/dials/data-files/raw/30e7df95d17ef152e1eef6e286a4f8143eac7c73/image_examples/SACLA-MPCCD-run266702-0-subset-known_orientations.expt
   - url: https://github.com/dials/data-files/raw/f587a81ac82b3c35a757492e92259a0105ee1c2a/image_examples/SACLA-MPCCD-run266702-0-subset.h5
   - url: https://github.com/dials/data-files/raw/2fc35b473ea4a9c68279e438d4e39e2662d9dfdb/image_examples/endonat3_001.mar2300
+  - url: https://github.com/dials/data-files/raw/410fd37833c792d8f009411a504ebd12d17ea03d/image_examples/SACLA-MPCCD-run197287-0-nexus.h5


### PR DESCRIPTION
3 images from CXI.DB entry 221, https://cxidb.org/id-221.html

Images reformatted as NeXus NXmx format by Takanori Nakane, including parameter data_scale_factor, which accounts for a gain of 10