### PR TITLE
Extend indexing and image test files

### DIFF
--- a/dials_data/definitions/image_examples.yml
+++ b/dials_data/definitions/image_examples.yml
@@ -23,3 +23,4 @@ data:
   - url: https://github.com/dials/data-files/raw/f587a81ac82b3c35a757492e92259a0105ee1c2a/image_examples/SACLA-MPCCD-run266702-0-subset.h5
   - url: https://github.com/dials/data-files/raw/2fc35b473ea4a9c68279e438d4e39e2662d9dfdb/image_examples/endonat3_001.mar2300
   - url: https://github.com/dials/data-files/raw/410fd37833c792d8f009411a504ebd12d17ea03d/image_examples/SACLA-MPCCD-run197287-0-nexus.h5
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/image_examples/DLS_I23_germ_13KeV_0001.cbf

--- a/dials_data/definitions/indexing_test_data.yml
+++ b/dials_data/definitions/indexing_test_data.yml
@@ -1,5 +1,5 @@
 name: Test data for indexing tests
-author: Nicholas Devenish (2021)
+author: Nicholas Devenish (2021) and David Waterman (2024)
 license: various
 description: >
   Indexing data used for tests in DIALS.
@@ -9,4 +9,20 @@ data:
   - url: https://github.com/dials/data-files/raw/97d4d6f65f2548e3c29898605c56b88aacec936f/indexing_test_data/phi_scan.expt
   - url: https://github.com/dials/data-files/raw/97d4d6f65f2548e3c29898605c56b88aacec936f/indexing_test_data/phi_scan_old.expt
   - url: https://github.com/dials/data-files/raw/97d4d6f65f2548e3c29898605c56b88aacec936f/indexing_test_data/phi_scan_strong.pickle
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/i24_lyso_still-imported.json
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/i24_lyso_still-strong.pickle
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/imosflm_hg_mar-datablock.json
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/imosflm_hg_mar-experiments.json
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/imosflm_hg_mar-strong.pickle
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/multi_sweep-SWEEP1-experiments.json
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/multi_sweep-SWEEP1-strong.pickle
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/multi_sweep-SWEEP2-experiments.json
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/multi_sweep-SWEEP2-strong.pickle
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/multi_sweep-SWEEP3-experiments.json
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/multi_sweep-SWEEP3-strong.pickle
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/multi_sweep-SWEEP4-experiments.json
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/multi_sweep-SWEEP4-strong.pickle
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/multi_sweep-experiments.json
+  - url: https://github.com/dials/data-files/raw/7678650d1dab1506e757ec26cf545921098f43b2/indexing_test_data/multi_sweep-indexed.pickle
+
 


### PR DESCRIPTION
A few DIALS processing files used in indexing tests, plus one I23 image file used in various other tests. These have come from dials_regression, full provenance now unknown.
