### PR TITLE
Add example integrated XDS data files

### DIFF
--- a/dials_data/definitions/insulin_processed_xds_1.yml
+++ b/dials_data/definitions/insulin_processed_xds_1.yml
@@ -1,0 +1,11 @@
+name: XDS processed data from insulin example dataset
+author: James Beilsten-Edmands
+license: CC-BY 4.0
+description: >
+  Generated with xia2 $(dials.data get -q insulin) image_range=1,20 pipeline=3dii
+  DIALS version 3.24.3, XDS version BUILT=20241002.
+  Provides an XDS.INP and INTEGRATE.HKL file
+
+data:
+  - url: https://github.com/dials/data-files/raw/42014599c65ae14f9f7a01b9d44c13245b40843e/insulin_processed_xds/images_1_20/INTEGRATE.HKL
+  - url: https://github.com/dials/data-files/raw/42014599c65ae14f9f7a01b9d44c13245b40843e/insulin_processed_xds/images_1_20/XDS.INP

--- a/dials_data/definitions/insulin_processed_xds_2.yml
+++ b/dials_data/definitions/insulin_processed_xds_2.yml
@@ -1,0 +1,11 @@
+name: XDS processed data from insulin example dataset
+author: James Beilsten-Edmands
+license: CC-BY 4.0
+description: >
+  Generated with xia2 $(dials.data get -q insulin) image_range=26,45 pipeline=3dii
+  DIALS version 3.24.3, XDS version BUILT=20241002.
+  Provides an XDS.INP and INTEGRATE.HKL file
+
+data:
+  - url: https://github.com/dials/data-files/raw/42014599c65ae14f9f7a01b9d44c13245b40843e/insulin_processed_xds/images_26_45/INTEGRATE.HKL
+  - url: https://github.com/dials/data-files/raw/42014599c65ae14f9f7a01b9d44c13245b40843e/insulin_processed_xds/images_26_45/XDS.INP


### PR DESCRIPTION
Will be used for testing `dials.import_xds` and `xia2.multiplex`.

Need to be as two separate definitions so that each will be in a separate directory in dials.data, as `dials.import_xds` works by filename matching by default, and this is also how processed data comes out of xia2.